### PR TITLE
Bug/host variable interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 #### All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
+## [1.0.3] - 2016-03-31
+* host service definition normalized to match service alias allowing for all host container ships to be 
+  referenced by the correct alias
+
 ## [1.0.2] - 2016-03-24
 * Resolved a bug where an export operation was using an image declaration from the same `deploy` environment 
   instead of export definition

--- a/docs/config/example_host_config.yml
+++ b/docs/config/example_host_config.yml
@@ -1,0 +1,22 @@
+---
+# environments definition
+environments:
+  # data center definition
+  development:
+
+    # service alias
+    elasticsearch:
+    # Docker image to use for service.
+      image: 'registry_alias/library/elasticsearch:latest'
+      ulimits:
+        - name: memlock
+          soft: 3000000
+          hard: 3000000
+      log_config:
+        type: syslog
+        config:
+          syslog-tag: 'elasticsearch-data'
+          syslog-facility: 'local6'
+
+
+

--- a/docs/config/overview.rst
+++ b/docs/config/overview.rst
@@ -412,13 +412,6 @@ log_config            False    dict          json-file                | Defined 
 
 ulimits               False    dict          None                     | Defined user process resource limits for the
                                                                       | containers run time environment
-                                                                      |
-                                                                      | Example:
-                                                                      |
-                                                                      | ulimits:
-                                                                      |   - name: memlock
-                                                                      |    soft: 3000000
-                                                                      |    hard: 3000000
 
 restart_policy        False    dict          {}                       | This defines the behavior of the container
                                                                       | on failure

--- a/docs/config/overview.rst
+++ b/docs/config/overview.rst
@@ -412,10 +412,21 @@ log_config            False    dict          json-file                | Defined 
 
 ulimits               False    dict          None                     | Defined user process resource limits for the
                                                                       | containers run time environment
+                                                                      |
+                                                                      | Example:
+                                                                      |
+                                                                      | ulimits:
+                                                                      |   - name: memlock
+                                                                      |    soft: 3000000
+                                                                      |    hard: 3000000
 
 restart_policy        False    dict          {}                       | This defines the behavior of the container
                                                                       | on failure
 ===================== ======== ============= ======================== =============================================================
+
+.. literalinclude:: ./example_host_config.yml
+    :language: yaml
+    :linenos:
 
 Container Config Properties
 ===========================

--- a/freight_forwarder/commercial_invoice/commercial_invoice.py
+++ b/freight_forwarder/commercial_invoice/commercial_invoice.py
@@ -195,7 +195,6 @@ class CommercialInvoice(object):
                 if hosts is None:
                     container_ships[alias] = hosts
                 elif isinstance(hosts, list):
-                    alias = hosts.alias
                     container_ships[alias] = {}
 
                     for host in hosts:

--- a/freight_forwarder/const.py
+++ b/freight_forwarder/const.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; -*-
 from __future__ import unicode_literals
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 
 # docker api
 DOCKER_DEFAULT_TIMEOUT = 120

--- a/freight_forwarder/container/host_config.py
+++ b/freight_forwarder/container/host_config.py
@@ -496,7 +496,7 @@ class HostConfig(object):
             if value:
                 for ulimit in value:
                     if not isinstance(ulimit, dict):
-                        raise TypeError('each ulimit must be a dict: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}')
+                        raise TypeError('each ulimit must be a dict: { "name": "nofile", "soft": 1024, "hard", 2048 }}')
 
                     name = ulimit.get('name')
                     hard = ulimit.get('hard')

--- a/freight_forwarder/freight_forwarder.py
+++ b/freight_forwarder/freight_forwarder.py
@@ -10,7 +10,7 @@ import requests
 import psutil
 from yaml.representer import SafeRepresenter
 
-from .utils                 import normalize_keys, parse_hostname, logger
+from .utils                 import normalize_keys, parse_hostname, logger, normalize_value
 from .commercial_invoice    import CommercialInvoice
 from .config                import Config, ACTIONS_SCHEME, ConfigUnicode
 
@@ -369,7 +369,7 @@ class FreightForwarder(object):
         if commercial_invoice.transport_method == 'export':
             host_alias = commercial_invoice.transport_method
         else:
-            host_alias = commercial_invoice.transport_service.name
+            host_alias = normalize_value(commercial_invoice.transport_service.name).replace('-', '_')
 
         fleet = commercial_invoice.container_ships.get(
             host_alias,

--- a/tests/fixtures/test_freight_forwarder.yaml
+++ b/tests/fixtures/test_freight_forwarder.yaml
@@ -24,6 +24,11 @@ es-server:
   ports:
     - 8080:8080
 
+redis_srv:
+  image: tune_dev/tuneplatform/redis-server:latest
+  ports:
+    - 6379:6379
+
 environments:
   development:
     local:
@@ -55,3 +60,17 @@ environments:
             - 8080:8080
           links:
             - es-server
+
+  staging:
+    local:
+      hosts:
+        default: &staging_default
+          - address: https://192.168.99.100:2376
+            ssl_cert_path: /replace/me
+            verify: false
+        export: *staging_default
+        tomcat-test: *staging_default
+        redis_srv:
+          - address: https://redis_srv.example.com:2376
+            ssl_cert_path: /replace/me
+            verify: false

--- a/tests/unit/commercial_invoice_test.py
+++ b/tests/unit/commercial_invoice_test.py
@@ -214,7 +214,7 @@ class CommercialInvoiceCreateContainershipsTest(unittest.TestCase):
             action='deploy',
             data_center='local',
             environment='development',
-            transport_service='tomcat_test'
+            transport_service='tomcat-test'
         )
         self.assertEqual(len(commercial_invoice.container_ships), 3)
         self.assertIn('tomcat_test', commercial_invoice.container_ships.keys())

--- a/tests/unit/commercial_invoice_test.py
+++ b/tests/unit/commercial_invoice_test.py
@@ -234,14 +234,14 @@ class CommercialInvoiceCreateContainershipsTest(unittest.TestCase):
         hosts = self.freight_forwarder._config.get('hosts', 'environments', 'development', 'local')
         del hosts['default']
 
-        commercial_invoice = self.freight_forwarder.commercial_invoice(
+        self.freight_forwarder.commercial_invoice(
             action='deploy',
             data_center='local',
             environment='development',
             transport_service='tomcat-test'
         )
         self.assertEqual(mock_os.getenv.call_count, 3)
-        calls =  [call('DOCKER_TLS_VERIFY'), call('DOCKER_CERT_PATH'), call('DOCKER_HOST')]
+        calls = [call('DOCKER_TLS_VERIFY'), call('DOCKER_CERT_PATH'), call('DOCKER_HOST')]
         mock_os.getenv.assert_has_call(calls, any_order=True)
 
     @mock.patch.object(CommercialInvoice, '_create_registries', autospec=True)
@@ -262,7 +262,6 @@ class CommercialInvoiceCreateContainershipsTest(unittest.TestCase):
             transport_service='tomcat-test'
         )
         container_ships = commercial_invoice.container_ships.keys()
-        config_hosts = self.freight_forwarder.config.environments['staging']['local']['hosts'].keys()
         self.assertEqual(len(commercial_invoice.container_ships), 4)
         self.assertIn('tomcat_test', container_ships)
         self.assertIn('redis_srv', container_ships)

--- a/tests/unit/freight_forwarder_test.py
+++ b/tests/unit/freight_forwarder_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
+
 from tests import unittest, mock
 from mock import call
 
@@ -88,7 +89,6 @@ class FreightForwarderTest(unittest.TestCase):
         self.assertTrue(test_deployment)
 
         # Validate output of logging to ensure the correct host is output to the user
-        calls = [call('Running deploy'),
+        calls = [call('Running deploy.'),
                  call('dispatching service: ffbug-example-tomcat-test on host: https://192.168.99.100:2376.')]
-        self.assertLogs(logger=mock_logger, level='INFO')
         mock_logger.info.assert_has_calls(calls)

--- a/tests/unit/freight_forwarder_test.py
+++ b/tests/unit/freight_forwarder_test.py
@@ -29,7 +29,7 @@ class FreightForwarderTest(unittest.TestCase):
 
     @mock.patch('freight_forwarder.freight_forwarder.CommercialInvoice', create=True)
     def test_commercial_invoice_export_and_deploy_service(self, mock_commercial_invoice):
-        commercial_invoice = self.freight_forwarder.commercial_invoice(
+        self.freight_forwarder.commercial_invoice(
             action='export',
             data_center='local',
             environment='development',
@@ -37,7 +37,7 @@ class FreightForwarderTest(unittest.TestCase):
         )
         commercial_invoice_services = mock_commercial_invoice.call_args[1].get('services')
         self.assertEqual(commercial_invoice_services['tomcat_test']['build'],
-                          './Dockerfile')
+                         './Dockerfile')
         self.assertIsInstance(commercial_invoice_services['tomcat_test'], ConfigDict)
 
         self.assertNotIn('image', commercial_invoice_services['tomcat_test'].values())

--- a/tests/unit/freight_forwarder_test.py
+++ b/tests/unit/freight_forwarder_test.py
@@ -4,9 +4,13 @@ from __future__ import absolute_import, unicode_literals
 import os
 
 from tests import unittest, mock
+from mock import call
+
+from ..factories.registry_factory import RegistryV1Factory
 
 from freight_forwarder        import FreightForwarder
 from freight_forwarder.config import ConfigDict
+from freight_forwarder.commercial_invoice.commercial_invoice import CommercialInvoice
 
 
 class FreightForwarderTest(unittest.TestCase):
@@ -36,3 +40,55 @@ class FreightForwarderTest(unittest.TestCase):
         self.assertIsInstance(commercial_invoice_services['tomcat_test'], ConfigDict)
 
         self.assertNotIn('image', commercial_invoice_services['tomcat_test'].values())
+
+    @mock.patch.object(FreightForwarder, '_FreightForwarder__complete_distribution')
+    @mock.patch.object(FreightForwarder, '_FreightForwarder__dispatch')
+    @mock.patch.object(FreightForwarder, '_FreightForwarder__wait_for_dispatch')
+    @mock.patch.object(FreightForwarder, '_FreightForwarder__service_deployment_validation')
+    @mock.patch.object(FreightForwarder, '_FreightForwarder__write_state_file', autospec=True)
+    @mock.patch.object(FreightForwarder, '_FreightForwarder__validate_commercial_invoice')
+    @mock.patch('freight_forwarder.commercial_invoice.commercial_invoice.ContainerShip', create=True)
+    @mock.patch('freight_forwarder.freight_forwarder.logger', autospec=True)
+    def test_assemble_fleet_with_yaml_variables_in_hosts(self,
+                                                         mock_logger,
+                                                         mock_container_ship,
+                                                         mock_validate_commercial_invoice,
+                                                         mock_write_state_file,
+                                                         mock_service_deployment_validation,
+                                                         mock_wait_for_dispatch,
+                                                         mock_dispatch,
+                                                         mock_complete_distribution
+                                                         ):
+        """
+        Verify that feel is built correctly based on the provided configuration data
+        :param mock_commercial_invoice:
+        :return:
+        """
+        mock_registries = mock.patch.object(CommercialInvoice, '_create_registries', return_value={
+            'tune_dev': RegistryV1Factory(),
+            u'docker_hub': RegistryV1Factory()
+        })
+        mock_registries.start()
+        mock_transport_service = mock.MagicMock(return_value='tomcat-test')
+
+        self.freight_forwarder._bill_of_lading = {'failures': {}, 'successful': {}}
+        commercial_invoice = self.freight_forwarder.commercial_invoice(
+            action='deploy',
+            data_center='local',
+            environment='staging',
+            transport_service=mock_transport_service()
+        )
+        mock_validate_commercial_invoice.return_value = commercial_invoice
+
+        test_deployment = self.freight_forwarder.deploy_containers(
+            commercial_invoice
+        )
+
+        # Ensure output of deployment is True based on no errors during the deployment process
+        self.assertTrue(test_deployment)
+
+        # Validate output of logging to ensure the correct host is output to the user
+        calls = [call('Running deploy'),
+                 call('dispatching service: ffbug-example-tomcat-test on host: https://192.168.99.100:2376.')]
+        self.assertLogs(logger=mock_logger, level='INFO')
+        mock_logger.info.assert_has_calls(calls)


### PR DESCRIPTION
- updated documentation to resolve #19 
- added example for host_config
- resolves issues where the host_alias was referenced in `_create_container_ships` variable for hosts and not creating all the container_ships correctly based on hosts defined in the environment / data_centers host
