### PR TITLE
bug/deploy_restart_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [1.0.4-dev] - 2016-05-23
 * resolved bug in logic of `FreightForwarder.export` to verify `bill_of_lading` before starting the export operation
+* updated schema to support `restart` or `restart_policy` in freight-forwarder configuration file
+* removed requirement for `syslog-facility` in `log_config`
+* added additional method to change the restart options to a sane value if not defined for for a deploy operation 
+
 
 ## [1.0.3-dev] - 2016-05-18
 * host service definition normalized to match service alias allowing for all host container ships to be 

--- a/docs/config/example_host_config.yml
+++ b/docs/config/example_host_config.yml
@@ -17,6 +17,9 @@ environments:
         config:
           syslog-tag: 'elasticsearch-data'
           syslog-facility: 'local6'
+      restart_policy:
+        policy_name: 'on-failure'
+        maximum_retry_count: 15
 
 
 

--- a/docs/config/overview.rst
+++ b/docs/config/overview.rst
@@ -403,7 +403,7 @@ log_config            False    dict          json-file                | Defined 
                                                                       | docker engine version
                                                                       | Default Value:
                                                                       | {
-                                                                      |  "type": json-file,
+                                                                      |  "type": "json-file",
                                                                       |  "config": {
                                                                       |    "max-files": "2",
                                                                       |    "max-size": "100m"

--- a/freight_forwarder/cli/__init__.py
+++ b/freight_forwarder/cli/__init__.py
@@ -1,1 +1,0 @@
-__author__ = 'alexb'

--- a/freight_forwarder/cli/deploy.py
+++ b/freight_forwarder/cli/deploy.py
@@ -12,7 +12,9 @@ from .cli_mixin              import CliMixin
 class DeployCommand(CliMixin):
     """ The deploy command pulls an image from a Docker registry, stops the previous running containers, creates and starts
     new containers, and cleans up the old containers and images on a docker host. If the new container fails to start,
-    the previous container is restarted and the most recently created containers and image are removed.
+    the previous container is restarted and the most recently created containers and image are removed. A deployed
+    container by default will be configured with a restart_policy of `on-failure` with a `maximum_retry_count` of 5 for
+    the deployed service and all of its dependent and dependency services.
 
     :options:
       - ``-h, --help``      (info) - Show the help message

--- a/freight_forwarder/cli/marshaling_yard.py
+++ b/freight_forwarder/cli/marshaling_yard.py
@@ -12,6 +12,7 @@ class MarshalingYardCommand(object):
     """ MarshalingYard interacts with a docker registry and provides information concerning the images and tags.
 
       - ``--alias``        (optional) - The registry alias defined in freight-forwarder config file. defaults: 'default'.
+      - ``--verbose``      (optional) - Enable verbose output for selected action
 
       One of the options is required
 
@@ -53,6 +54,14 @@ class MarshalingYardCommand(object):
             default='default',
             type=str,
             help='registry alias created in freight-forwarder.yml. Example: tune_dev'
+        )
+
+        self._parser.add_argument(
+            '-D', '--verbose',
+            required=False,
+            action='store_true',
+            default=False,
+            help='enable verbose output'
         )
 
 

--- a/freight_forwarder/commercial_invoice/__init__.py
+++ b/freight_forwarder/commercial_invoice/__init__.py
@@ -4,5 +4,3 @@ from __future__ import unicode_literals, absolute_import
 
 from .commercial_invoice   import CommercialInvoice
 from .service              import Service
-
-__author__ = 'alexb'

--- a/freight_forwarder/config.py
+++ b/freight_forwarder/config.py
@@ -475,7 +475,6 @@ ROOT_SCHEME = {
                 },
                 'config': {
                     'is': {
-                        'required': ['syslog-facility'],
                         'type': dict
                     },
                     'syslog-facility': {
@@ -634,6 +633,31 @@ ROOT_SCHEME = {
             'restart': {
                 'is': {
                     'type': dict
+                },
+                'policy_name': {
+                    'is': {
+                        'type': six.string_types
+                    }
+                },
+                'maximum_retry_count': {
+                    'is': {
+                        'type': int
+                    }
+                }
+            },
+            'restart_policy': {
+                'is': {
+                    'type': dict
+                },
+                'policy_name': {
+                    'is': {
+                        'type': six.string_types
+                    }
+                },
+                'maximum_retry_count': {
+                    'is': {
+                        'type': int
+                    }
                 }
             },
             'security_opt': {

--- a/freight_forwarder/container/__init__.py
+++ b/freight_forwarder/container/__init__.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8; -*-
 # flake8: noqa
-__author__ = 'alexander'
 from .container import Container


### PR DESCRIPTION
- updated `config.py` to support `restart` and `restart_policy` in freight-forwarder config
- removed requirement for `syslog-facility` for `config` in `log_config`
- added protected method to configure restart_policy for transport_services and it's associated dependents / dependencies
- updated documentation for restart_policy on deploy
- added verbose argument to MarshalingYard
