### PR TITLE
bug/delete_raises_exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 #### All notable changes to this project will be documented in this file. This project adheres to Semantic Versioning.
 
-## [1.0.4-dev] - 2016-05-23
+## [1.0.4-dev] - 2016-06-07
 * resolved bug in logic of `FreightForwarder.export` to verify `bill_of_lading` before starting the export operation
+* added better error handling when deleting a container
 
 ## [1.0.3-dev] - 2016-05-18
 * host service definition normalized to match service alias allowing for all host container ships to be 

--- a/freight_forwarder/container_ship.py
+++ b/freight_forwarder/container_ship.py
@@ -134,7 +134,7 @@ class ContainerShip(object):
         self._service_map(service, anonymous, descending=False)
 
     def containers(self):
-        self._client_session.containers(all=1)
+        return self._client_session.containers(all=1)
 
     def load_containers(self, service, configs, use_cache):
         """


### PR DESCRIPTION
- updated `Container.delete()` to allow for verification of a `dead` container and perform an alternative action, but notify the user
- updated `ContainerShip.containers` to return containers on the host
- updated logging for validating a 'dead' container state
- updated container delete tests to facilitate improved checking in method
